### PR TITLE
🐛 bugfix[#3] : PreAuthWebFilter가 두번씩 도는 버그 fix

### DIFF
--- a/com.sparta.logistics.gateway/src/main/java/com/sparta/logistics/gateway/security/config/SecurityConfig.java
+++ b/com.sparta.logistics.gateway/src/main/java/com/sparta/logistics/gateway/security/config/SecurityConfig.java
@@ -1,6 +1,9 @@
 package com.sparta.logistics.gateway.security.config;
 
+import com.sparta.logistics.gateway.jwt.JwtUtil;
 import com.sparta.logistics.gateway.security.filter.PreAuthWebFilter;
+import com.sparta.logistics.gateway.security.service.BlackListCheck;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
@@ -14,11 +17,21 @@ import org.springframework.security.web.server.context.NoOpServerSecurityContext
 
 @Configuration
 @EnableWebFluxSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
 
+    private final JwtUtil jwtUtil;
+    private final BlackListCheck blackListCheck;
+
     @Bean
-    public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http,
-        PreAuthWebFilter preAuthWebFilter) {
+    public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http
+        ) {
+
+        /*
+        PreAuthWebFilter 가 두번씩 동작하는 현상 발생. PreAuthWebFilter 의 컴포넌트 어노테이션을 제거한 후
+        시큐리티 웹 필터체인 안에 직접 생성하여 사용. -> 한번만 사용됨.
+         */
+        PreAuthWebFilter preAuthWebFilter = new PreAuthWebFilter(jwtUtil, blackListCheck);
 
         // JWT 토큰 사용으로 무상태 요청을 유지하기 위한 설정.
         http

--- a/com.sparta.logistics.gateway/src/main/java/com/sparta/logistics/gateway/security/service/BlackListCheck.java
+++ b/com.sparta.logistics.gateway/src/main/java/com/sparta/logistics/gateway/security/service/BlackListCheck.java
@@ -10,8 +10,8 @@ public class BlackListCheck {
 
     private final StringRedisTemplate stringRedisTemplate;
 
-    public boolean isBlacklisted(String token) {
-        String key = "blacklist" + token;
+    public boolean isBlacklisted(String token, String tokenType) {
+        String key = "blacklist:" + tokenType + ":" + token;
         return Boolean.TRUE.equals(stringRedisTemplate.hasKey(key));
     }
 

--- a/com.sparta.logistics.gateway/src/main/resources/application.yml
+++ b/com.sparta.logistics.gateway/src/main/resources/application.yml
@@ -135,20 +135,6 @@ eureka:
     service-url:
       defaultZone: http://${EUREKA_URL}/eureka/
 
-logging:
-  level:
-    org.springframework.cloud.gateway: DEBUG
-    org.springframework.security: DEBUG
-    com.sparta.logistics.gateway: DEBUG
-management:
-  endpoints:
-    web:
-      exposure:
-        include: gateway, routes, health, info
-  endpoint:
-    gateway:
-      enabled: true
-
 jwt:
   secret:
     key: ${JWT_SECRET_KEY}


### PR DESCRIPTION
## ✨ 변경 타입
* [ ] 신규 기능 추가/수정
* [x] 버그 수정
* [x] 리팩토링
* [ ] 설정
* [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## ✅ 체크리스트

* [x] 코드 작성 가이드라인을 준수했는가?
* [x] 변경 사항에 대한 테스트를 완료했는가?
* [ ] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

## 🚀 변경 내용
* **as-is**
  * PreAuthWebFilter가 두번씩 도는 버그 발생.

* **to-be**
  * 중복 동작 없이 한번만 동작하도록 fix

## 💡 추가 설명

* @Component 어노테이션으로 인해 스프링 컨텍스트에 두번 등록되어 api 호출시 필터가 두번씩 도는 버그가 있었음.
* 해당 어노테이션을 제거하여 자동 빈 등록을 막고 SecurityWebFilterChain 내부에 수동으로 등록하여 한번만 동작하도록 수정하였음.
* 그외 리프레쉬 토큰 블랙리스트 검증과 하위 서비스에 전달할 커스텀 헤더에 AccessToken, RefreshToken을 추가하여 블랙리스트 등록을 일관성있게 진행하도록 수정하였음.

## 📚 참고 자료 (선택 사항)
문제 해결을 위해 찾아본 스택 오버플로우 주소입니다.
https://stackoverflow.com/questions/65971799/how-to-avoid-spring-webflux-filter-from-being-called-twice

* 관련 자료 링크
