### PR TITLE
✨ feat[#9] : 토큰 재발급 기능 추가

### DIFF
--- a/com.sparta.logistics.user-service/build.gradle
+++ b/com.sparta.logistics.user-service/build.gradle
@@ -43,6 +43,9 @@ dependencies {
 	// passwordEncoder
 	implementation 'org.mindrot:jbcrypt:0.4'
 
+	// validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
 	// lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/com.sparta.logistics.user-service/src/main/java/com/sparta/logistics/user_service/application/dto/request/AuthSignupRequestDto.java
+++ b/com.sparta.logistics.user-service/src/main/java/com/sparta/logistics/user_service/application/dto/request/AuthSignupRequestDto.java
@@ -1,5 +1,7 @@
 package com.sparta.logistics.user_service.application.dto.request;
 
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -7,8 +9,20 @@ import lombok.Getter;
 @Builder
 public class AuthSignupRequestDto {
 
+    @Size(min = 4, max = 10, message = "username 은 최소 4자 이상, 10자 이하여야 합니다.")
+    @Pattern(
+        regexp = "^[a-z0-9]+$",
+        message = "username 은 알파벳 소문자와 숫자로만 구성되어야 합니다."
+    )
     private String username;
+
+    @Size(min = 8, max = 15, message = "password 는 최소 8자 이상, 15자 이하여야 합니다.")
+    @Pattern(
+        regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?~`])[a-zA-Z0-9!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?~`]+$",
+        message = "password 는 알파벳 대소문자, 숫자, 특수문자로만 구성되어야 합니다."
+    )
     private String password;
+
     private String slackId;
 
 }

--- a/com.sparta.logistics.user-service/src/main/java/com/sparta/logistics/user_service/application/dto/request/UserPasswordUpdateRequestDto.java
+++ b/com.sparta.logistics.user-service/src/main/java/com/sparta/logistics/user_service/application/dto/request/UserPasswordUpdateRequestDto.java
@@ -1,11 +1,25 @@
 package com.sparta.logistics.user_service.application.dto.request;
 
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
 public class UserPasswordUpdateRequestDto {
+
+    @Size(min = 8, max = 15, message = "old password 는 최소 8자 이상, 15자 이하여야 합니다.")
+    @Pattern(
+        regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?~`])[a-zA-Z0-9!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?~`]+$",
+        message = "old password 는 알파벳 대소문자, 숫자, 특수문자로만 구성되어야 합니다."
+    )
     private String oldPassword;
+
+    @Size(min = 8, max = 15, message = "new password 는 최소 8자 이상, 15자 이하여야 합니다.")
+    @Pattern(
+        regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?~`])[a-zA-Z0-9!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?~`]+$",
+        message = "new password 는 알파벳 대소문자, 숫자, 특수문자로만 구성되어야 합니다."
+    )
     private String newPassword;
 }

--- a/com.sparta.logistics.user-service/src/main/java/com/sparta/logistics/user_service/application/dto/request/UserUpdateRequestDto.java
+++ b/com.sparta.logistics.user-service/src/main/java/com/sparta/logistics/user_service/application/dto/request/UserUpdateRequestDto.java
@@ -1,11 +1,20 @@
 package com.sparta.logistics.user_service.application.dto.request;
 
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
 public class UserUpdateRequestDto {
+
+    @Size(min = 4, max = 10, message = "new username 은 최소 4자 이상, 10자 이하여야 합니다.")
+    @Pattern(
+        regexp = "^[a-z0-9]+$",
+        message = "new username 은 알파벳 소문자와 숫자로만 구성되어야 합니다."
+    )
     private String newUsername;
+
     private String newSlackId;
 }

--- a/com.sparta.logistics.user-service/src/main/java/com/sparta/logistics/user_service/application/dto/response/AuthTokenRefreshResponseDto.java
+++ b/com.sparta.logistics.user-service/src/main/java/com/sparta/logistics/user_service/application/dto/response/AuthTokenRefreshResponseDto.java
@@ -1,0 +1,13 @@
+package com.sparta.logistics.user_service.application.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AuthTokenRefreshResponseDto {
+
+    private String newAccessToken;
+    private String newRefreshToken;
+
+}

--- a/com.sparta.logistics.user-service/src/main/java/com/sparta/logistics/user_service/application/service/AuthService.java
+++ b/com.sparta.logistics.user-service/src/main/java/com/sparta/logistics/user_service/application/service/AuthService.java
@@ -3,16 +3,19 @@ package com.sparta.logistics.user_service.application.service;
 import com.sparta.logistics.user_service.application.dto.request.AuthLoginRequestDto;
 import com.sparta.logistics.user_service.application.dto.request.AuthSignupRequestDto;
 import com.sparta.logistics.user_service.application.dto.response.AuthSignupResponseDto;
+import com.sparta.logistics.user_service.application.dto.response.AuthTokenRefreshResponseDto;
 import com.sparta.logistics.user_service.application.dto.response.AuthTokenResponseDto;
 import com.sparta.logistics.user_service.domain.entity.User;
-import com.sparta.logistics.user_service.domain.entity.UserRole;
 import com.sparta.logistics.user_service.domain.repository.UserRepository;
 import com.sparta.logistics.user_service.jwt.JwtUtil;
 import jakarta.persistence.EntityNotFoundException;
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import org.mindrot.jbcrypt.BCrypt;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -22,6 +25,9 @@ public class AuthService {
     private final UserRepository userRepository;
     private final JwtUtil jwtUtil;
     private final StringRedisTemplate stringRedisTemplate;
+
+    @Value("${jwt.refresh.exp}")
+    private Long jwtRefreshExpTime;
 
     // 회원가입
     public AuthSignupResponseDto createUser(AuthSignupRequestDto requestDto, String userIdHeader) {
@@ -47,7 +53,15 @@ public class AuthService {
         }
 
         String accessToken = jwtUtil.createAccessToken(user.getId(), user.getUsername(), user.getRole().name());
-        String refreshToken = jwtUtil.createRefreshToken(user.getId(), user.getUsername(), user.getRole().name());
+        String refreshToken = jwtUtil.createRefreshToken(user.getId());
+
+        // 레디스에 리프레쉬 토큰 저장
+        stringRedisTemplate.opsForValue().set(
+            "whitelist:RT:" + user.getId(),
+            refreshToken,
+            jwtRefreshExpTime,
+            TimeUnit.MILLISECONDS
+        );
 
         return AuthTokenResponseDto.builder()
             .accessToken(accessToken)
@@ -56,25 +70,71 @@ public class AuthService {
     }
 
     // 로그아웃
-    public void logoutUser(String accessToken, String refreshToken) {
-        long accessTokenExpCheck = jwtUtil.getMilliSecond(accessToken);
-        long refreshTokenExpCheck = jwtUtil.getMilliSecond(refreshToken);
+    public void logoutUser(String accessToken, String refreshToken, String userIdHeader) {
+        /*
+         * 이 부분만 Wrapper 타입인 Long 으로 선언하지 않은 이유는
+         * userRepository 에서 찾아오는 로직이 없기 때문에 null 값을 허용할 이유가 없음.
+         * parseLong()이 반환하는 원시타입인 long 으로 받도록 설정.
+         */
+        long userId = Long.parseLong(userIdHeader);
 
-        // 레디스에 블랙리스트 토큰 저장.
+        Long accessTokenExpCheck = jwtUtil.getMilliSecond(accessToken);
+        Long refreshTokenExpCheck = jwtUtil.getMilliSecond(refreshToken);
+
+        // 레디스에 블랙리스트 엑세스 토큰 저장.
         stringRedisTemplate.opsForValue().set(
-            "blacklist" + accessToken,
+            "blacklist:AT:" + accessToken,
             "LOGOUT",
             accessTokenExpCheck,
             TimeUnit.MILLISECONDS
         );
 
+        // 레디스에 블랙리스트 리프레쉬 토큰 저장.
         stringRedisTemplate.opsForValue().set(
-            "blacklist" + refreshToken,
+            "blacklist:RT:" + refreshToken,
             "LOGOUT",
             refreshTokenExpCheck,
             TimeUnit.MILLISECONDS
         );
 
+        stringRedisTemplate.delete("whitelist:RT:" + userId);
+
+    }
+
+    // 엑세스 토큰 만료시 리프레쉬 토큰 발급
+    public AuthTokenRefreshResponseDto tokenRefresh(String oldRefreshToken, String userIdHeader) {
+        Long userId = Long.parseLong(userIdHeader);
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new EntityNotFoundException("토큰 재발급 : 해당하는 유저가 없습니다 userId : " + userId));
+
+        String newAccessToken = jwtUtil.createAccessToken(user.getId(), user.getUsername(), user.getRole().name());
+        String newRefreshToken = jwtUtil.createRefreshToken(user.getId());
+
+        long refreshTokenExpCheck = jwtUtil.getMilliSecond(newRefreshToken);
+
+        // 화이트리스트에 등록할 새로운 리프레쉬 토큰을 위해 기존 화이트리스트에 저장된 리프레쉬 토큰 삭제
+        stringRedisTemplate.delete("whitelist:RT:" + user.getId());
+
+        // 기존 리프레쉬 토큰을 블랙리스트에 등록
+        stringRedisTemplate.opsForValue().set(
+            "blacklist:RT:" + oldRefreshToken,
+            "TOKEN_REFRESH",
+            refreshTokenExpCheck,
+            TimeUnit.MILLISECONDS
+        );
+
+        // 새로운 리프레쉬 토큰을 화이트리스트에 등록
+        stringRedisTemplate.opsForValue().set(
+            "whitelist:RT:" + user.getId(),
+            newRefreshToken,
+            jwtRefreshExpTime,
+            TimeUnit.MILLISECONDS
+        );
+
+        return AuthTokenRefreshResponseDto.builder()
+            .newAccessToken(newAccessToken)
+            .newRefreshToken(newRefreshToken)
+            .build();
     }
 
     // 회원가입시 마스터가 생성하는 것을 가정하여 마스터의 userId를 생성자 필드에 넣을 수 있도록 메서드 제작. master 가 아니라면 기본값 0l 넣기

--- a/com.sparta.logistics.user-service/src/main/java/com/sparta/logistics/user_service/domain/entity/User.java
+++ b/com.sparta.logistics.user-service/src/main/java/com/sparta/logistics/user_service/domain/entity/User.java
@@ -16,6 +16,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.SQLRestriction;
 import org.hibernate.type.SqlTypes;
 import org.mindrot.jbcrypt.BCrypt;
 
@@ -25,6 +26,7 @@ import org.mindrot.jbcrypt.BCrypt;
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "p_user")
+@SQLRestriction("deleted_at IS NULL")
 public class User extends BaseEntity {
 
     @Id

--- a/com.sparta.logistics.user-service/src/main/java/com/sparta/logistics/user_service/jwt/JwtUtil.java
+++ b/com.sparta.logistics.user-service/src/main/java/com/sparta/logistics/user_service/jwt/JwtUtil.java
@@ -20,8 +20,6 @@ import org.springframework.stereotype.Component;
 @Component
 @Slf4j(topic = "JwtUil")
 public class JwtUtil {
-    public static final String AUTHORIZATION_HEADER = "Authorization";
-    public static final String BEARER_PREFIX = "Bearer ";
     private static final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
 
     @Value("${jwt.secret.key}")
@@ -83,32 +81,6 @@ public class JwtUtil {
         return exp.getTime() - now;
     }
 
-    // 헤더에서 추출한 토큰의 Bearer 접두사 제거
-    public String removeBearer(String bearerToken) {
-        if (bearerToken != null && bearerToken.startsWith(BEARER_PREFIX)) {
-            return bearerToken.substring(BEARER_PREFIX.length());
-        }
-        log.error("bearer 접두사를 찾을 수 없거나 토큰이 존재하지 않음. 받은 토큰 : " + bearerToken);
-        return null;
-    }
-
-    // 토큰 유효성 검사
-    public boolean validateToken(String token) {
-        try {
-            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
-            return true;
-        } catch (SecurityException | MalformedJwtException e) {
-            log.error("Invalid JWT signature");
-        } catch (ExpiredJwtException e) {
-            log.error("Expired JWT token");
-        } catch (UnsupportedJwtException e) {
-            log.error("Unsupported JWT token");
-        } catch (IllegalArgumentException e) {
-            log.error("JWT claims is empty");
-        }
-        return false;
-    }
-
     // 토큰에서 user 데이터 가져오기
     public Claims getUserInfoFromToken(String token) {
         // 토큰 파싱하여 리턴
@@ -118,6 +90,5 @@ public class JwtUtil {
             .parseClaimsJws(token)
             .getBody();
     }
-
 
 }

--- a/com.sparta.logistics.user-service/src/main/java/com/sparta/logistics/user_service/jwt/JwtUtil.java
+++ b/com.sparta.logistics.user-service/src/main/java/com/sparta/logistics/user_service/jwt/JwtUtil.java
@@ -54,14 +54,12 @@ public class JwtUtil {
     }
 
     // refresh 토큰 생성
-    public String createRefreshToken(Long userId, String username, String role) {
+    public String createRefreshToken(Long userId) {
         Date now = new Date();
         Date expirationDate = new Date(now.getTime() + jwtRefreshExpTime);
 
         return Jwts.builder()
             .setSubject(String.valueOf(userId))
-            .claim("username", username)
-            .claim("role", role)
             .setIssuedAt(now)
             .setExpiration(expirationDate)
             .signWith(key, signatureAlgorithm)
@@ -75,7 +73,7 @@ public class JwtUtil {
     }
 
     // 토큰 만료시간 계산
-    public long getMilliSecond(String token) {
+    public Long getMilliSecond(String token) {
         Date exp = getExpiration(token);
         long now = System.currentTimeMillis();
         return exp.getTime() - now;

--- a/com.sparta.logistics.user-service/src/main/java/com/sparta/logistics/user_service/presentation/controller/AuthController.java
+++ b/com.sparta.logistics.user-service/src/main/java/com/sparta/logistics/user_service/presentation/controller/AuthController.java
@@ -5,6 +5,7 @@ import com.sparta.logistics.user_service.application.dto.request.AuthSignupReque
 import com.sparta.logistics.user_service.application.dto.response.AuthSignupResponseDto;
 import com.sparta.logistics.user_service.application.dto.response.AuthTokenResponseDto;
 import com.sparta.logistics.user_service.application.service.AuthService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -24,7 +25,7 @@ public class AuthController {
 
     // 회원가입
     @PostMapping("/auth/signup")
-    public ResponseEntity<AuthSignupResponseDto> createUser(@RequestBody AuthSignupRequestDto requestDto,
+    public ResponseEntity<AuthSignupResponseDto> createUser(@Valid @RequestBody AuthSignupRequestDto requestDto,
                                                             @RequestHeader(value = "X-User-Id", required = false) String userIdHeader
     ) {
         AuthSignupResponseDto responseDto = authService.createUser(requestDto, userIdHeader);

--- a/com.sparta.logistics.user-service/src/main/java/com/sparta/logistics/user_service/presentation/controller/AuthController.java
+++ b/com.sparta.logistics.user-service/src/main/java/com/sparta/logistics/user_service/presentation/controller/AuthController.java
@@ -3,10 +3,15 @@ package com.sparta.logistics.user_service.presentation.controller;
 import com.sparta.logistics.user_service.application.dto.request.AuthLoginRequestDto;
 import com.sparta.logistics.user_service.application.dto.request.AuthSignupRequestDto;
 import com.sparta.logistics.user_service.application.dto.response.AuthSignupResponseDto;
+import com.sparta.logistics.user_service.application.dto.response.AuthTokenRefreshResponseDto;
 import com.sparta.logistics.user_service.application.dto.response.AuthTokenResponseDto;
 import com.sparta.logistics.user_service.application.service.AuthService;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
+import lombok.Value;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.Mapping;
@@ -34,19 +39,49 @@ public class AuthController {
 
     // 로그인
     @PostMapping("/auth/login")
-    public ResponseEntity<AuthTokenResponseDto> loginUser(@RequestBody AuthLoginRequestDto requestDto
+    public ResponseEntity<AuthTokenResponseDto> loginUser(@RequestBody AuthLoginRequestDto requestDto,
+                                                          HttpServletResponse servletResponse
     ) {
         AuthTokenResponseDto responseDto = authService.loginUser(requestDto);
+
+        ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", responseDto.getRefreshToken())
+            .httpOnly(true)
+            .secure(true)
+            .maxAge(Duration.ofDays(1))
+            .path("/")
+            .build();
+        servletResponse.addHeader("Set-Cookie", refreshTokenCookie.toString());
+
         return ResponseEntity.ok(responseDto);
     }
 
     // 로그아웃
     @PostMapping("/auth/logout")
-    public ResponseEntity<String> logoutUser(@RequestHeader(value = "X-Access-Token") String accessTokenHeader,
-                                             @RequestHeader(value = "X-Refresh-Token") String refreshTokenHeader
-    ) {
-        authService.logoutUser(accessTokenHeader, refreshTokenHeader);
+    public ResponseEntity<String> logoutUser(@RequestHeader(value = "X-User-Id") String userIdHeader,
+                                             @RequestHeader(value = "X-ACCESS-TOKEN") String accessToken,
+                                             @RequestHeader(value = "X-REFRESH-TOKEN") String refreshToken
+        ) {
+        authService.logoutUser(accessToken, refreshToken, userIdHeader);
         return ResponseEntity.ok("로그아웃이 완료되었습니다.");
+    }
+
+    // Token 재발급
+    @PostMapping("/auth/refresh")
+    public ResponseEntity<AuthTokenRefreshResponseDto> tokenRefresh(@RequestHeader(value = "X-User-Id") String userIdHeader,
+                                                                    @RequestHeader(value = "X-REFRESH-TOKEN") String oldRefreshToken,
+                                                                    HttpServletResponse servletResponse
+        ) {
+        AuthTokenRefreshResponseDto responseDto = authService.tokenRefresh(oldRefreshToken, userIdHeader);
+
+        ResponseCookie refreshTokenCookie = ResponseCookie.from("refreshToken", responseDto.getNewRefreshToken())
+            .httpOnly(true)
+            .secure(true)
+            .maxAge(Duration.ofDays(1))
+            .path("/")
+            .build();
+        servletResponse.addHeader("Set-Cookie", refreshTokenCookie.toString());
+
+        return ResponseEntity.ok(responseDto);
     }
 
 }

--- a/com.sparta.logistics.user-service/src/main/java/com/sparta/logistics/user_service/presentation/controller/UserController.java
+++ b/com.sparta.logistics.user-service/src/main/java/com/sparta/logistics/user_service/presentation/controller/UserController.java
@@ -9,6 +9,7 @@ import com.sparta.logistics.user_service.application.dto.response.UserSearchMeRe
 import com.sparta.logistics.user_service.application.dto.response.UserSearchResponseDto;
 import com.sparta.logistics.user_service.application.dto.response.UserUpdateResponseDto;
 import com.sparta.logistics.user_service.application.service.UserService;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -73,7 +74,7 @@ public class UserController {
     // 유저 수정 : 본인 비밀번호 수정
     @PutMapping("/users/password")
     public ResponseEntity<String> updatePassword(@RequestHeader(value = "X-User-Id") String userIdHeader,
-                                                 @RequestBody UserPasswordUpdateRequestDto requestDto
+                                                 @Valid @RequestBody UserPasswordUpdateRequestDto requestDto
     ) {
         userService.updatePassword(userIdHeader, requestDto);
         return ResponseEntity.ok("비밀번호가 변경되었습니다.");
@@ -84,7 +85,7 @@ public class UserController {
     @PutMapping("master/users/{userId}")
     public ResponseEntity<UserUpdateResponseDto> updateUser(@PathVariable("userId") Long userId,
                                                             @RequestHeader(value = "X-User-Id") String userIdHeader,
-                                                            @RequestBody UserUpdateRequestDto requestDto
+                                                            @Valid @RequestBody UserUpdateRequestDto requestDto
     ) {
         UserUpdateResponseDto responseDto = userService.updateUser(userId, requestDto, userIdHeader);
         return ResponseEntity.ok(responseDto);
@@ -101,7 +102,7 @@ public class UserController {
     }
 
     // MASTER : 회원 탈퇴
-    @DeleteMapping("/users/{userId}")
+    @DeleteMapping("/master/users/{userId}")
     public ResponseEntity<String> deleteUser(@RequestHeader(value = "X-User-Id") String userIdHeader,
                                              @PathVariable("userId") Long userId
     ) {


### PR DESCRIPTION
## ✨ 변경 타입
* [x] 신규 기능 추가/수정
* [ ] 버그 수정
* [x] 리팩토링
* [ ] 설정
* [ ] 비기능 (주석 등 기능에 영향을 주지 않음)

## ✅ 체크리스트

* [x] 코드 작성 가이드라인을 준수했는가?
* [x] 변경 사항에 대한 테스트를 완료했는가?
* [ ] 문서 변경이 필요한 경우, 해당 내용을 반영했는가?

## 🚀 변경 내용
* **as-is**
  * 리프레쉬 토큰을 발급만 하고 따로 사용하지는 않음.
  * 엑세스 토큰 만료시 토큰 재발급 기능 존재하지 않음

* **to-be**
  * 토큰 재발급 기능 추가
  * 쿠키에 리프레쉬 토큰을 담아서 전송

## 💡 추가 설명

* 토큰 재발급시 리프레쉬 토큰을 사용하여 재발급. 재발급시 기존 토큰은 레디스에 블랙리스트로 등록
* 처음 로그인시 리프레쉬 토큰을 쿠키에 담아서 반환. 해당 리프레쉬 토큰은 레디스의 화이트리스트로 등록
* 정규표현식을 사용하여 발제에서 제한한 사항으로 usernmae, password 받도록 수정.
* 좀더 자세한 설명은 커밋메세지 설명란에 달아두었습니다.

## 📚 참고 자료 (선택 사항)

* 관련 자료 링크
